### PR TITLE
Add __pycache__ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+__pycache__
 /bookmarks/
 quickmarks


### PR DESCRIPTION
I have this theme as a submodule in my dotfiles repository. Having the active theme as a repo causes a `__pycache__` directory to be generated, so let's ignore that for git's sake.